### PR TITLE
Add profile updates, playlist deletion, and artist track management

### DIFF
--- a/riffstream_final/add_track.php
+++ b/riffstream_final/add_track.php
@@ -1,0 +1,130 @@
+<?php
+require __DIR__ . '/common.php';
+require __DIR__ . '/db.php';
+require_login();
+
+// Pull account type to verify artist access
+$stmt = $pdo->prepare('SELECT account_type FROM users WHERE user_id = ?');
+$stmt->execute([$_SESSION['user_id']]);
+$user = $stmt->fetch();
+
+if (!$user) {
+    die('User not found.');
+}
+
+if ($user['account_type'] !== 'Artist') {
+    header('Location: dashboard.php?msg=' . urlencode('Tracks are available to artist accounts only.'));
+    exit;
+}
+
+$error = '';
+$success = '';
+$title = '';
+$genre = '';
+$album_name = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title      = trim($_POST['title'] ?? '');
+    $genre      = trim($_POST['genre'] ?? '');
+    $album_name = trim($_POST['album_name'] ?? '');
+
+    if ($title === '') {
+        $error = 'Please provide a track title.';
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO tracks (user_id, title, genre, album_name, created_at) VALUES (?, ?, ?, ?, NOW())');
+        $stmt->execute([$_SESSION['user_id'], $title, $genre ?: null, $album_name ?: null]);
+
+        $success = 'Track added to your catalog.';
+        $title = $genre = $album_name = '';
+    }
+}
+
+$listStmt = $pdo->prepare('SELECT title, genre, album_name, created_at FROM tracks WHERE user_id = ? ORDER BY created_at DESC');
+$listStmt->execute([$_SESSION['user_id']]);
+$tracks = $listStmt->fetchAll();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RiffStream · Add a track</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <main class="card" role="main">
+      <div class="header-row">
+        <img src="images/logo.svg" alt="RiffStream logo" class="logo">
+        <div>
+          <h1>Add a track</h1>
+          <p>Simple metadata entry for artists. File upload is optional and stored later.</p>
+        </div>
+      </div>
+
+      <?php if ($error): ?>
+        <div class="error"><?php echo h($error); ?></div>
+      <?php elseif ($success): ?>
+        <div class="success"><?php echo h($success); ?></div>
+      <?php endif; ?>
+
+      <form method="post" action="add_track.php" enctype="multipart/form-data" novalidate>
+        <div class="form-row">
+          <label for="title">Track title</label>
+          <input class="input" type="text" id="title" name="title" value="<?php echo h($title); ?>" required maxlength="150">
+        </div>
+
+        <div class="grid-2">
+          <div class="form-row">
+            <label for="genre">Genre</label>
+            <input class="input" type="text" id="genre" name="genre" value="<?php echo h($genre); ?>" maxlength="80" placeholder="e.g., Synthwave">
+          </div>
+          <div class="form-row">
+            <label for="album_name">Album/EP name</label>
+            <input class="input" type="text" id="album_name" name="album_name" value="<?php echo h($album_name); ?>" maxlength="150" placeholder="Optional">
+          </div>
+        </div>
+
+        <div class="form-row">
+          <label for="audio_file">Audio file (optional placeholder)</label>
+          <input class="input" type="file" id="audio_file" name="audio_file" accept="audio/*">
+          <div class="meta">File upload is shown for UI completeness; this demo does not store the file.</div>
+        </div>
+
+        <div class="actions">
+          <button type="submit">Save track</button>
+          <a class="link" href="dashboard.php">Back to dashboard</a>
+        </div>
+      </form>
+
+      <h2 style="margin-top:24px;">Your uploaded tracks</h2>
+      <?php if (empty($tracks)): ?>
+        <div class="note">No tracks yet. Add one above to start building your catalog.</div>
+      <?php else: ?>
+        <ul class="stacked-list">
+          <?php foreach ($tracks as $t): ?>
+            <li>
+              <div class="item-top">
+                <div>
+                  <strong><?php echo h($t['title']); ?></strong>
+                  <div class="meta">Added <?php echo h($t['created_at']); ?></div>
+                  <div class="meta">
+                    <?php
+                      $bits = [];
+                      if ($t['genre'])      { $bits[] = 'Genre: ' . h($t['genre']); }
+                      if ($t['album_name']) { $bits[] = 'Album: ' . h($t['album_name']); }
+                      echo $bits ? implode(' · ', $bits) : '—';
+                    ?>
+                  </div>
+                </div>
+              </div>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+
+      <div class="footer">Tracks are stored in the <code>tracks</code> table and filtered by your artist account.</div>
+    </main>
+  </div>
+</body>
+</html>

--- a/riffstream_final/dashboard.php
+++ b/riffstream_final/dashboard.php
@@ -249,6 +249,11 @@ $flash_msg = isset($_GET['msg']) ? $_GET['msg'] : '';
           </div>
 
           <div class="row">
+            <a class="btn" href="update_profile.php">Edit profile</a>
+            <a class="btn btn-secondary" href="delete_playlist.php">Manage playlists</a>
+            <?php if ($isArtist): ?>
+              <a class="btn" href="add_track.php">Add track</a>
+            <?php endif; ?>
             <a class="btn" href="logout.php">Log out</a>
           </div>
         </section>

--- a/riffstream_final/database.sql
+++ b/riffstream_final/database.sql
@@ -7,7 +7,10 @@ CREATE DATABASE IF NOT EXISTS `riffstream`
 
 USE `riffstream`;
 
+DROP TABLE IF EXISTS `tracks`;
+DROP TABLE IF EXISTS `playlists`;
 DROP TABLE IF EXISTS `users`;
+
 CREATE TABLE `users` (
   `user_id`      INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `first_name`   VARCHAR(50)  NOT NULL,
@@ -18,6 +21,29 @@ CREATE TABLE `users` (
   `account_type` ENUM('Listener','Artist') NOT NULL DEFAULT 'Listener',
   `created_at`   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `playlists` (
+  `playlist_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id`     INT UNSIGNED NOT NULL,
+  `name`        VARCHAR(120) NOT NULL,
+  `description` VARCHAR(255) DEFAULT NULL,
+  `created_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`playlist_id`),
+  CONSTRAINT `fk_playlists_user` FOREIGN KEY (`user_id`)
+    REFERENCES `users`(`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `tracks` (
+  `track_id`    INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id`     INT UNSIGNED NOT NULL,
+  `title`       VARCHAR(150) NOT NULL,
+  `genre`       VARCHAR(80)  DEFAULT NULL,
+  `album_name`  VARCHAR(150) DEFAULT NULL,
+  `created_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`track_id`),
+  CONSTRAINT `fk_tracks_user` FOREIGN KEY (`user_id`)
+    REFERENCES `users`(`user_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Sample users (password hashes are placeholders for grading).
@@ -34,5 +60,15 @@ INSERT INTO `users` (first_name, last_name, username, email, password_hash, acco
 ('Avery','Taylor','ataylor8','ataylor8@example.com','sample_hash_here','Listener',NOW()),
 ('Quinn','Anderson','qanderson9','qanderson9@example.com','sample_hash_here','Listener',NOW()),
 ('Skyler','Thomas','sthomas10','sthomas10@example.com','sample_hash_here','Artist',NOW());
+
+INSERT INTO `playlists` (user_id, name, description) VALUES
+  (2, 'Morning Mix', 'Upbeat songs for a productive morning'),
+  (3, 'Focus Flow', 'Instrumental tracks that help with studying'),
+  (5, 'Weekend Drive', 'Road trip essentials');
+
+INSERT INTO `tracks` (user_id, title, genre, album_name) VALUES
+  (1, 'Neon Skies', 'Synthwave', 'City Lights EP'),
+  (4, 'Echoes of Dawn', 'Indie Rock', 'First Light'),
+  (7, 'Midnight Frequencies', 'Electronic', 'Night Shift');
 
 

--- a/riffstream_final/delete_playlist.php
+++ b/riffstream_final/delete_playlist.php
@@ -1,0 +1,66 @@
+<?php
+require __DIR__ . '/common.php';
+require __DIR__ . '/db.php';
+require_login();
+
+$stmt = $pdo->prepare('SELECT user_id, account_type FROM users WHERE user_id = ?');
+$stmt->execute([$_SESSION['user_id']]);
+$me = $stmt->fetch();
+
+$flash = $_GET['msg'] ?? '';
+
+$playlistsStmt = $pdo->prepare('SELECT playlist_id, name, description, created_at FROM playlists WHERE user_id = ? ORDER BY created_at DESC');
+$playlistsStmt->execute([$_SESSION['user_id']]);
+$playlists = $playlistsStmt->fetchAll();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RiffStream · Delete a playlist</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <main class="card" role="main">
+      <div class="header-row">
+        <img src="images/logo.svg" alt="RiffStream logo" class="logo">
+        <div>
+          <h1>Your playlists</h1>
+          <p>Choose a playlist to remove. Deleting a playlist does not affect tracks themselves.</p>
+        </div>
+      </div>
+
+      <?php if ($flash): ?>
+        <div class="success"><?php echo h($flash); ?></div>
+      <?php endif; ?>
+
+      <?php if (empty($playlists)): ?>
+        <div class="note">No playlists found. Create one on the dashboard, then you can delete it here.</div>
+      <?php else: ?>
+        <ul class="stacked-list">
+          <?php foreach ($playlists as $pl): ?>
+            <li>
+              <div class="item-top">
+                <div>
+                  <strong><?php echo h($pl['name']); ?></strong>
+                  <div class="meta">Created <?php echo h($pl['created_at']); ?></div>
+                  <?php if (!empty($pl['description'])): ?>
+                    <div class="meta">"<?php echo h($pl['description']); ?>"</div>
+                  <?php endif; ?>
+                </div>
+                <a class="btn btn-danger" href="delete_playlist_confirm.php?id=<?php echo h($pl['playlist_id']); ?>">Delete</a>
+              </div>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+
+      <div class="actions">
+        <a class="btn btn-secondary" href="dashboard.php">Back to dashboard</a>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/riffstream_final/delete_playlist_confirm.php
+++ b/riffstream_final/delete_playlist_confirm.php
@@ -1,0 +1,68 @@
+<?php
+require __DIR__ . '/common.php';
+require __DIR__ . '/db.php';
+require_login();
+
+$playlistId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+
+$stmt = $pdo->prepare('SELECT playlist_id, name, description FROM playlists WHERE playlist_id = ? AND user_id = ?');
+$stmt->execute([$playlistId, $_SESSION['user_id']]);
+$playlist = $stmt->fetch();
+
+if (!$playlist) {
+    die('Playlist not found or not owned by you.');
+}
+
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $del = $pdo->prepare('DELETE FROM playlists WHERE playlist_id = ? AND user_id = ? LIMIT 1');
+    $del->execute([$playlist['playlist_id'], $_SESSION['user_id']]);
+
+    if ($del->rowCount() > 0) {
+        header('Location: delete_playlist.php?msg=' . urlencode('Playlist "' . $playlist['name'] . '" deleted.'));
+        exit;
+    } else {
+        $error = 'Unable to delete that playlist. Please try again.';
+    }
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RiffStream · Confirm delete</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <main class="card" role="main">
+      <div class="header-row">
+        <img src="images/logo.svg" alt="RiffStream logo" class="logo">
+        <div>
+          <h1>Delete playlist</h1>
+          <p>Are you sure you want to delete "<?php echo h($playlist['name']); ?>"?</p>
+        </div>
+      </div>
+
+      <?php if ($error): ?>
+        <div class="error"><?php echo h($error); ?></div>
+      <?php endif; ?>
+
+      <?php if (!empty($playlist['description'])): ?>
+        <div class="note">Description: <?php echo h($playlist['description']); ?></div>
+      <?php endif; ?>
+
+      <form method="post" action="delete_playlist_confirm.php?id=<?php echo h($playlist['playlist_id']); ?>">
+        <div class="actions">
+          <button type="submit" class="btn btn-danger">Yes, delete it</button>
+          <a class="btn btn-secondary" href="delete_playlist.php">Cancel</a>
+        </div>
+      </form>
+
+      <div class="footer">Deletion uses a prepared DELETE statement scoped to your account.</div>
+    </main>
+  </div>
+</body>
+</html>

--- a/riffstream_final/style.css
+++ b/riffstream_final/style.css
@@ -102,6 +102,14 @@ button, .btn {
   justify-content: center;
 }
 
+.btn-secondary {
+  background: linear-gradient(180deg, #7689a6, #536178);
+}
+
+.btn-danger {
+  background: linear-gradient(180deg, #ff7b8a, #ff5d6c);
+}
+
 button:hover, .btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 30px rgba(58,134,255,0.35);
@@ -144,6 +152,30 @@ button:disabled {
   grid-template-columns: 1fr 1fr;
   gap: 12px;
 }
+
+.stacked-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 10px;
+}
+
+.stacked-list li {
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: rgba(255,255,255,0.03);
+}
+
+.item-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.meta { color: var(--muted); font-size: 13px; margin-top: 4px; }
 
 @media (max-width: 520px) {
   .grid-2 { grid-template-columns: 1fr; }

--- a/riffstream_final/update_profile.php
+++ b/riffstream_final/update_profile.php
@@ -1,0 +1,139 @@
+<?php
+require __DIR__ . '/common.php';
+require __DIR__ . '/db.php';
+require_login();
+
+// Fetch current user details for pre-filling the form
+$stmt = $pdo->prepare('SELECT user_id, first_name, last_name, email, account_type FROM users WHERE user_id = ?');
+$stmt->execute([$_SESSION['user_id']]);
+$me = $stmt->fetch();
+
+if (!$me) {
+    die('User not found.');
+}
+
+$error = '';
+$success = '';
+
+$first_name   = $me['first_name'];
+$last_name    = $me['last_name'];
+$email        = $me['email'];
+$account_type = $me['account_type'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $first_name   = trim($_POST['first_name'] ?? '');
+    $last_name    = trim($_POST['last_name'] ?? '');
+    $email        = trim($_POST['email'] ?? '');
+    $account_type = $_POST['account_type'] ?? 'Listener';
+    $new_password = $_POST['new_password'] ?? '';
+    $confirm_pw   = $_POST['confirm_password'] ?? '';
+
+    if ($first_name === '' || $last_name === '' || $email === '') {
+        $error = 'Please fill in all required fields.';
+    } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $error = 'Please enter a valid email address.';
+    } elseif (!in_array($account_type, ['Listener', 'Artist'], true)) {
+        $error = 'Please choose a valid account type.';
+    } elseif ($new_password !== '' && $new_password !== $confirm_pw) {
+        $error = 'New password and confirmation do not match.';
+    } elseif ($new_password !== '' && strlen($new_password) < 8) {
+        $error = 'If setting a new password, it must be at least 8 characters.';
+    } else {
+        // Ensure the email is unique for another account
+        $check = $pdo->prepare('SELECT COUNT(*) AS c FROM users WHERE email = ? AND user_id <> ?');
+        $check->execute([$email, $me['user_id']]);
+        if (($check->fetch()['c'] ?? 0) > 0) {
+            $error = 'That email address is already in use by another account.';
+        } else {
+            $params = [$first_name, $last_name, $email, $account_type, $me['user_id']];
+            $setPassword = '';
+
+            if ($new_password !== '') {
+                $hash = password_hash($new_password, PASSWORD_DEFAULT);
+                $setPassword = ', password_hash = ?';
+                array_splice($params, 4, 0, [$hash]); // insert hash before user_id
+            }
+
+            $sql = 'UPDATE users SET first_name = ?, last_name = ?, email = ?, account_type = ?' . $setPassword . ' WHERE user_id = ? LIMIT 1';
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute($params);
+
+            $_SESSION['email']        = $email;
+            $_SESSION['account_type'] = $account_type;
+            $success = 'Profile updated successfully.';
+        }
+    }
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RiffStream · Update Profile</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <main class="card" role="main">
+      <div class="header-row">
+        <img src="images/logo.svg" alt="RiffStream logo" class="logo">
+        <div>
+          <h1>Edit your profile</h1>
+          <p>Update your basic information. Leave password blank to keep your current one.</p>
+        </div>
+      </div>
+
+      <?php if ($error): ?>
+        <div class="error"><?php echo h($error); ?></div>
+      <?php elseif ($success): ?>
+        <div class="success"><?php echo h($success); ?></div>
+      <?php endif; ?>
+
+      <form method="post" action="update_profile.php" novalidate>
+        <div class="grid-2">
+          <div class="form-row">
+            <label for="first_name">First name</label>
+            <input class="input" type="text" id="first_name" name="first_name" value="<?php echo h($first_name); ?>" required maxlength="50">
+          </div>
+          <div class="form-row">
+            <label for="last_name">Last name</label>
+            <input class="input" type="text" id="last_name" name="last_name" value="<?php echo h($last_name); ?>" required maxlength="50">
+          </div>
+        </div>
+
+        <div class="form-row">
+          <label for="email">Email</label>
+          <input class="input" type="email" id="email" name="email" value="<?php echo h($email); ?>" required maxlength="120">
+        </div>
+
+        <div class="form-row">
+          <label for="account_type">Account type</label>
+          <select id="account_type" name="account_type" class="input" required>
+            <option value="Listener" <?php echo $account_type === 'Listener' ? 'selected' : ''; ?>>Listener</option>
+            <option value="Artist" <?php echo $account_type === 'Artist' ? 'selected' : ''; ?>>Artist</option>
+          </select>
+        </div>
+
+        <div class="grid-2">
+          <div class="form-row">
+            <label for="new_password">New password</label>
+            <input class="input" type="password" id="new_password" name="new_password" minlength="8" autocomplete="new-password" placeholder="Leave blank to keep current">
+          </div>
+          <div class="form-row">
+            <label for="confirm_password">Confirm new password</label>
+            <input class="input" type="password" id="confirm_password" name="confirm_password" minlength="8" autocomplete="new-password" placeholder="Re-type new password">
+          </div>
+        </div>
+
+        <div class="actions">
+          <button type="submit">Save changes</button>
+          <a class="link" href="dashboard.php">Back to dashboard</a>
+        </div>
+      </form>
+
+      <div class="footer">Profile updates write to the <code>users</code> table using prepared statements.</div>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add update_profile.php to let users edit core account fields with optional password changes
- provide playlist deletion flow with listing and confirmation pages using prepared statements
- add artist-only track creation page plus schema updates for playlists and tracks
- update shared styles and dashboard actions to surface the new features

## Testing
- php -l update_profile.php
- php -l delete_playlist.php
- php -l delete_playlist_confirm.php
- php -l add_track.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c0694c88832e8fb0cea9cc8803ce)